### PR TITLE
.env and cli support for cf spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ typings/
 .next
 
 .idea/
+
+#vs code debugging
+.vscode

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Pick one of the remote systems above and edit your ui5.yaml file according to it
 
 You have the option to use all parameters as is from the ui5.yaml file or overwrite few of them when executing ui5-cli.
 
-You can overwrite: `abapRepository.transportRequest` || `credentials.username` || `credentials.password`
+You can overwrite: `abapRepository.transportRequest` || `credentials.username` || `credentials.password` || `sapCloudPlatform.cloudFoundry.space`
 
 ```shell script
 $ ui5-deployer deploy
@@ -190,6 +190,10 @@ $ ui5-deployer deploy --transport-request=ABAPDK99999
 
 ```shell script
 $ ui5-deployer deploy --username=MyUsername --password=MyPassword
+```
+
+```shell script
+$ ui5-deployer deploy --space=dev
 ```
 
 You can see an example here:
@@ -208,6 +212,7 @@ UI5_DEPLOYER_USERNAME=MY_SAP_USER
 UI5_DEPLOYER_PASSWORD=MY_SAP_PASSWORD
 UI5_DEPLOYER_ABAP_TR=ABAPDK999999
 UI5_DEPLOYER_NEO_CLIPATH=/path/to/neo/cli/
+UI5_DEPLOYER_CF_SPACE=dev
 ```
 
 If you are using `.env` files, do not push them to your git repo as you may expose the secrets to everbody! Make sure to add `.env` to your `.gitignore` file.

--- a/lib/cli/cli/commands/deployer.js
+++ b/lib/cli/cli/commands/deployer.js
@@ -27,9 +27,15 @@ deploy.builder = function(cli) {
         default: '',
         type: 'string',
       })
+      .option('space', {
+        describe: 'Cloud Foundry space to deploy the app into',
+        default: '',
+        type: 'string',
+      })
       .example('ui5 deploy', 'Deploy project with all parameters from ui5.yaml file.')
       .example('ui5 deploy --transport-request=ABAPDK99999', 'Deploy project with the given ABAP Transport Request')
-      .example('ui5 deploy --username=MyUsername --password=MyPassword', 'Deploy project with the given credentials');
+      .example('ui5 deploy --username=MyUsername --password=MyPassword', 'Deploy project with the given credentials')
+      .example('ui5 deploy --space=dev', 'Deploy project into the given Cloud Foundry space');
 };
 
 async function handleDeploy(argv) {
@@ -50,6 +56,7 @@ async function handleDeploy(argv) {
     transportRequest: argv['transport-request'],
     username: argv.username,
     password: argv.password,
+    space: argv.space
   });
 }
 

--- a/lib/deployer/deployer.js
+++ b/lib/deployer/deployer.js
@@ -2,6 +2,7 @@
 
 const logger = require('@ui5/logger').getGroupLogger('deployer:deployer');
 const {resourceFactory} = require('@ui5/fs');
+const {deployer} = require('..');
 const typeRepository = require('../types/typeRepository');
 
 require('dotenv').config();
@@ -32,9 +33,12 @@ function setPropertiesWithEnv(deployerConfig) {
   if (process.env.UI5_DEPLOYER_NEO_CLIPATH && deployerConfig.sapCloudPlatform && deployerConfig.sapCloudPlatform.neo) {
     deployerConfig.sapCloudPlatform.neo.cliPath = process.env.UI5_DEPLOYER_NEO_CLIPATH;
   }
+  if (process.env.UI5_DEPLOYER_CF_SPACE && deployerConfig.sapCloudPlatform && deployerConfig.sapCloudPlatform.cloudFoundry) {
+    deployerConfig.sapCloudPlatform.cloudFoundry.space = process.env.UI5_DEPLOYER_CF_SPACE;
+  }
 }
 
-function setPropertiesWithCLI(deployerConfig, transportRequest, username, password) {
+function setPropertiesWithCLI(deployerConfig, transportRequest, username, password, space) {
   if (transportRequest && deployerConfig.abapRepository) {
     deployerConfig.abapRepository.transportRequest = transportRequest;
   }
@@ -43,6 +47,9 @@ function setPropertiesWithCLI(deployerConfig, transportRequest, username, passwo
   }
   if (password) {
     deployerConfig.credentials.password = password;
+  }
+  if (space && deployerConfig.sapCloudPlatform && deployerConfig.sapCloudPlatform.cloudFoundry) {
+    deployerConfig.sapCloudPlatform.cloudFoundry.space = space;
   }
 }
 
@@ -72,9 +79,10 @@ module.exports = {
      * @param {string} parameters.transportRequest ABAP Transport Request
      * @param {string} parameters.username Username to log into the target system
      * @param {string} parameters.password Password to log into the target system
+     * @param {string} parameters.space Cloud Foundry space
      * @return {Promise} Promise resolving to <code>undefined</code> once deploy has finished
      */
-  async deploy({tree, transportRequest, username, password}) {
+  async deploy({tree, transportRequest, username, password, space}) {
     logger.info(`Deploying project ${tree.metadata.name}`);
     const startTime = process.hrtime();
     const project = tree;
@@ -85,7 +93,7 @@ module.exports = {
       project.deployer.credentials = {};
     }
     setPropertiesWithEnv(project.deployer);
-    setPropertiesWithCLI(project.deployer, transportRequest, username, password);
+    setPropertiesWithCLI(project.deployer, transportRequest, username, password, space);
     const excludes = getExclusions(project.deployer);
     const projectType = typeRepository.getType(project.deployer.type);
     const workspace = resourceFactory.createAdapter({

--- a/lib/deployer/deployer.js
+++ b/lib/deployer/deployer.js
@@ -2,7 +2,6 @@
 
 const logger = require('@ui5/logger').getGroupLogger('deployer:deployer');
 const {resourceFactory} = require('@ui5/fs');
-const {deployer} = require('..');
 const typeRepository = require('../types/typeRepository');
 
 require('dotenv').config();


### PR DESCRIPTION
Hi @mauriciolauffer ,
I implemented .env and cli support for cf spaces. By now deployment to different cf spaces (e.g. dev, qa, prod) requires different yaml files. This is not needed anymore with this PR. 

Best regards,
Marcel